### PR TITLE
Nulogy sequence assignment patch

### DIFF
--- a/dockerimages/postgres-client/scripts/generate-sequences-sql.sh
+++ b/dockerimages/postgres-client/scripts/generate-sequences-sql.sh
@@ -4,6 +4,7 @@ set -exo pipefail
 
 WORKFLOW=$1
 SCHEMA=$2
+SEQEUNCE_CMDS=$3
 
 /scripts/prep-certs.sh
 
@@ -12,4 +13,8 @@ PSQL="psql --quiet --tuples-only --no-align"
 # generate DDL to restore sequences which needs to be done in advance of remaining DDL
 pg_dump --schema=${SCHEMA} -s -O -x | awk '/[CREATE|ALTER] SEQUENCE/ {print}' FS="\n" RS="" | curl -X POST -H "Transfer-Encoding: chunked" -s -T - http://agent-http-nas:3000/file/${WORKFLOW}%2Fschema-${SCHEMA}-sequences.sql
 
-$PSQL -c "SELECT public.generate_sequences('${SCHEMA}');" | curl -X POST -H "Transfer-Encoding: chunked" -s -f -T - http://agent-http-nas:3000/file/${WORKFLOW}%2Fschema-${SCHEMA}-set-sequences.sql
+# Nulogy patch for setting sequences
+if [ -z "$SEQUENCE_CMDS" ]
+then
+    echo $SEQEUNCE_CMDS | curl -X POST -H "Transfer-Encoding: chunked" -s -f -T - http://agent-http-nas:3000/file/${WORKFLOW}%2Fschema-${SCHEMA}-set-sequences.sql
+fi


### PR DESCRIPTION
Eventually this code should be moved into a branch fork within the Github Nulogy org, but it doesn't make sense to do that right now since the branch it is based off hasn't yet been merged to main. In the meantime, this PR review will help review and process the patch code.

The problem with the documented way of restoring sequences is that these recipes restore these values based on the data that currently resides in the table. However, Nulogy can't do this since the sequences are all shared in the public schema across all tenancies in account schema. There is no great way to derive these values.

So, instead, we record these values from the source prior to the data dump so they can replayed on the target. The problem with this approach is that any new rows that are entered after the sequences have been dumped will make the dump file, yet the sequence data will be too old and this will cause primary key conflicts.

However, Nulogy can mitigate this simply by ensuring that the public schema is the last Redactics workflow that is run so that there are guarantees that the sequence values will be higher than the older data copied from preceding workflows (i.e. account schema workflows).

This patch works by altering the Airflow dynamic task mapping function for the sequence generation command that dictates what Kubernetes command should be run by retrieving all of the sequence values and passing them into the script run within the task container. When this value is present, this data is transferred to the Redactics internal disk which is mounted by each task step. These values are then replayed as one of the final steps of the workflow.

The `generate-sequences-sql` script will also contain a code block for generating sequence data the "normal" way, i.e.:

`SETVAL('public.users', COALESCE(MAX(' id'), 1) )`

This will be added back to this script outside of this PR, but I'm bringing this up to explain that one way or another, there will always be a `schema-${SCHEMA}-set-sequences.sql` file set, which means that no patch is required to replay these values, this file is simply read and executed as is.